### PR TITLE
Queueing image feature

### DIFF
--- a/availableHarvester.js
+++ b/availableHarvester.js
@@ -1,0 +1,100 @@
+/*
+** This is the harvester handler. It will handle requests to '/available'.
+** This handler will receive messages from the plant queue that contain
+** information for a new plant image uploaded to plant bucket.
+** 
+** It will then send the image to another Harvester handler that will 
+** read the message and load the image for identifying
+*/
+
+const AWS = require('aws-sdk');
+
+var AWS_Region = process.env.AWS_REGION;
+
+var sqs = new AWS.SQS({region: AWS_Region});
+var lambda = new AWS.Lambda({region: AWS_Region});
+var s3 = new AWS.S3({region: AWS_Region});
+
+function receiveMessage(callback) {
+  var params = {
+    Queue_Url: PLANT_QUEUE_URL,
+    MaxNumberOfMessages: 1
+  };
+  sqs.receiveMessage(params, function(err, data) {
+    if (err) {
+       console.error(err, err.stack);
+       callback(err);
+    } else {
+       callback(null, data.Messages);
+    }
+  });
+}
+
+function invokeHarvesterLambda(task, callback) {
+   var params {
+     FunctionName = HARVESTER_LAMBDA_NAME,
+     InvocationType = 'Event',
+     Payload: JSON.stringify(task)
+   };
+   lambda.invoke(params, function(err, data) {
+     if (err) {
+        console.error(err, err.stack);
+        callback(err);
+     } else {
+        callback(null, data.Messages);
+     }
+   });
+}
+   
+
+function handleSQSMessage(context, callback) {
+  receiveMessage(function(err, message) {
+    if (message && message.length > 0) {
+       var invocations[];
+       invocations.push(function(callback) {
+         invokeHarvesterLambda(message, callback);
+       });
+      async.parallel(invocations, function(err) {
+        if (err) {
+          console.error(err, err.stack);
+          callback(err);
+        } else {
+          callback(null, 'PAUSE');
+        }
+      });
+    } else {
+      callback(null, 'DONE');
+    }
+  });
+}
+
+
+module.exports.receivePlantImage = function (event, context, callback) {
+   console.log("HERE");
+}
+
+
+function deleteMessage(receiptHandle, cb) {
+
+  sqs.deleteMessage({
+    ReceiptHandle: receiptHandle,
+    QueueUrl: PLANT_QUEUE_URL
+  }, cb);
+}
+
+
+function work(task, cb) {
+   console.log(task);
+   cb();
+}
+
+
+module.exports.harvesterlambda = function (event, context, callback) {
+   work(event.Body, function(err) {
+     if (err) {
+        callback(err);
+     } else {
+        deleteMessage(event.ReceiptHandle, callback);
+     }
+   });
+};

--- a/serverless.yml
+++ b/serverless.yml
@@ -66,6 +66,24 @@ functions:
           path: berries/{id}
           method: delete
           cors: true
+  
+  receivePlantImage:
+    handler: availableHarvester.receivePlantImage
+    environment:
+      PLANT_QUEUE_URL: kotokaplantqueue
+      HARVESTER_LAMBDA_NAME: harvesterlambda
+    events:
+      - http:
+          path: available
+          method: get
+          cors: true 
+
+  harvesterlambda:
+    handler: availableHarvester.processPlantImage
+    environment:
+      PLANT_QUEUE_URL: kotokaplantqueue
+      PLANT_BUCKET: plantimagebucket
+      
 
 resources:
   Resources:
@@ -86,13 +104,12 @@ resources:
           WriteCapacityUnits: 1
         TableName: ${self:provider.environment.DYNAMODB_TABLE}
  
-    plantQueue:
+    kotokaplantqueue:
       Type: "AWS::SQS::Queue"
       Properties:
         QueueName: "kotokaplantqueue"
  
-    kotokaBucket:
+    plantimagebucket:
       Type: "AWS::S3::Bucket"
       Properties:
-        BucketName: "kotokabucket"
-     
+        BucketName: "plantimagebucket"


### PR DESCRIPTION
Check my code for bugs. Currently, the new lambda functions are triggered when one makes a GET request to /available. This will cause receiveImage to trigger. In that function, the message is read and sent to another lambda function that will use the image contents to retrieve an object from s3. 

Check for bugs and potential holes. Specifically in availableHarvester.js

I also fixed the console.log("HERE") line in availableHarvester.js receivePlantImage function in the next commit. 
That should be HandleSQSMessage(context, callback);